### PR TITLE
Promises and error propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ The native stream.Transform does not provide concurrent operations out of the bo
 * Issues 'end' only when all incoming pipes have ended
 * Issues 'finish' only when all incoming pipes have ended and any concurrent functions have finished
 * Provides downstream pipes in all instances.  If nothing is "pushed", the downstream pipe will only receive the end event (at the right time).
+* Passes errors down to the first listener in the chain
+* Provides an easy transition to final promise that is resolved on `finish` and rejected on `error`
 
 The stream initiation is as follows (can be called with or without `new`):
 
@@ -39,3 +41,7 @@ Customstream.prototype._flush = function(cb) {
   });
 };
 ```
+
+Any errors that come up in a streamz object are passed to the children if no custom error listener has been defined.  This allows errors to propagate down to the first error listener or to the rejection of a final promise (if the chain ends in `.promise()`)
+
+A chain that ends with `.promise()` returns a promise that collects any data passed down in an array and resolves when the stream is `finished` or is rejected if any uncaught error occured.   If no data is passed down to the end, the promise simply resolves to an empty array.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streamz",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "A Swiss-army-knife of a stream",
   "keywords": [
     "asynchronous",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "asynchronous",
     "stream"
   ],
-  "scripts" : {
-    "test" : "mocha"
+  "scripts": {
+    "test": "mocha"
   },
   "author": "Ziggy Jonsson (http://github.com/zjonsson/)",
   "repository": {
@@ -16,7 +16,7 @@
   },
   "main": "streamz.js",
   "license": "MIT",
-  "devDependencies": {
-    "bluebird": "^2.10.2"
+  "dependencies": {
+    "bluebird": "~3.2.2"
   }
 }

--- a/streamz.js
+++ b/streamz.js
@@ -1,4 +1,5 @@
 var stream = require('stream'),
+    Promise = require('bluebird'),
     util = require('util');
 
 function noop() {}
@@ -145,6 +146,22 @@ Streamz.prototype.end = function(d) {
       this._transform.apply(this,arguments);
   } else
     stream.Transform.prototype.end.apply(this,arguments);
+};
+
+Streamz.prototype.promise = function() {
+  var defer = Promise.defer(),
+      buffer=[],
+      bufferStream = Streamz(function(d) {
+        buffer = buffer.concat(d);
+      });
+
+  this.pipe(bufferStream)
+    .on('error',defer.reject.bind(defer))
+    .on('finish',function() {
+      defer.resolve(buffer);
+    });
+
+  return defer.promise;
 };
 
 module.exports = Streamz;

--- a/streamz.js
+++ b/streamz.js
@@ -41,6 +41,16 @@ function Streamz(_c,fn,options) {
   this._incomingPipes = 0;
   this._concurrent = 0;
 
+  this.on('error',function(e) {
+    if (this._events.error.length < 2) {
+      var pipes = this._readableState.pipes;
+      if (pipes) [].concat(pipes).forEach(function(child) {
+          child.emit('error',e);
+        });
+      else throw e;
+    }
+  });
+
   this.on('pipe',function() {
     this._incomingPipes++;
   });

--- a/test/error-propagation-test.js
+++ b/test/error-propagation-test.js
@@ -1,0 +1,72 @@
+var streamz = require('../streamz'),
+    Promise = require('bluebird'),
+    assert = require('assert');
+
+var values = [1,2,3,4,5,6,7,8,9];
+
+var valueStream = function() {
+  var s = require('stream').PassThrough({objectMode:true});
+  values.forEach(function(d,i) {
+    setTimeout(function() {
+      s.write(d);
+      if (i == values.length -1)
+        s.end();
+    },i*1);
+  });
+  return s;
+};
+
+describe('error propagation',function() {
+
+ it('handled by next handler',function() {
+  var max,err;
+
+  valueStream()
+    .pipe(streamz(function(d) {        
+      if (d == 5) return Promise.reject('EXCEPTION');
+      else return d;
+    }))
+    .pipe(streamz(function(d) {
+      max = d;
+    }))
+    .pipe(streamz())
+    .pipe(streamz())
+    .on('error',function(e) {
+      err = e;
+    })
+    .pipe(streamz())
+    .on('error',function() {
+      err = 'should not be picked up here';
+    });
+  
+    return Promise.delay(200)
+      .then(function() {
+        assert.equal(err,'EXCEPTION');
+        assert.equal(max,4);
+    });
+  });
+
+
+  it('handled by promise rejection',function() {
+    var max,err;
+
+    return valueStream()
+      .pipe(streamz(function(d) {        
+        if (d == 5) return Promise.reject('EXCEPTION');
+        else return Promise.resolve(d);
+      }))
+      .pipe(streamz(function(d) {
+        max = d;
+      }))
+      .pipe(streamz())
+      .pipe(streamz())
+      .promise()
+      .catch(function(e) {
+        err = e;
+      })  
+      .then(function() {
+        assert.equal(err,'EXCEPTION');
+        assert.equal(max,4);
+      });
+  });
+});

--- a/test/function-test.js
+++ b/test/function-test.js
@@ -11,6 +11,7 @@ function sum(d,m) {
 }
 
 function test(s,m) {
+  s.setMaxListeners(1000);
   source(values).pipe(s);
     
   return inspect(s)

--- a/test/promise-test.js
+++ b/test/promise-test.js
@@ -1,0 +1,39 @@
+var streamz = require('../streamz'),
+    assert = require('assert');
+
+var values = [1,2,3,4,5,6,7,8,9];
+
+var valueStream = function() {
+  var s = require('stream').PassThrough({objectMode:true});
+  values.forEach(function(d,i) {
+    setTimeout(function() {
+      s.write(d);
+      if (i == values.length -1)
+        s.end();
+    },i*1);
+  });
+  return s;
+};
+
+describe('promise',function() {
+  it('concats data and resolves on finish',function() {
+    return valueStream()
+      .pipe(streamz())
+      .pipe(streamz())
+      .promise()
+      .then(function(d) {
+        assert.deepEqual(d,values);
+      });
+  });
+
+  it('resolves with empty array if no data',function() {
+    return valueStream()
+      .pipe(streamz())
+      .pipe(streamz())
+      .pipe(streamz(function() {}))
+      .promise()
+      .then(function(d) {
+        assert.deepEqual(d,[]);
+      });
+  });
+});


### PR DESCRIPTION
Add promises support (resolve on finish, rejects on error) and ensures that errors are propagated down a streamz chain when no custom error listeners are present