### PR TITLE
Change `.defer` to `new Promise()`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streamz",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "A Swiss-army-knife of a stream",
   "keywords": [
     "asynchronous",

--- a/streamz.js
+++ b/streamz.js
@@ -155,17 +155,19 @@ Streamz.prototype.end = function(d) {
 };
 
 Streamz.prototype.promise = function() {
-  var defer = Promise.defer(),
+  var self = this,
       buffer=[],
       bufferStream = Streamz(function(d) {
         buffer.push(d);
       });
 
-  this.pipe(bufferStream)
-    .on('error',defer.reject.bind(defer))
-    .on('finish',defer.resolve.bind(defer,buffer));
-
-  return defer.promise;
+  return new Promise(function(resolve,reject) {
+    self.pipe(bufferStream)
+      .on('error',reject)
+      .on('finish',function() {
+        resolve(buffer)
+      });
+  });
 };
 
 module.exports = Streamz;


### PR DESCRIPTION
Removes bluebird warning: https://github.com/petkaantonov/bluebird/wiki/Promise-anti-patterns#the-deferred-anti-pattern