### PR TITLE
Capture errors from above

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streamz",
-  "version": "1.5.3",
+  "version": "1.6.0",
   "description": "A Swiss-army-knife of a stream",
   "keywords": [
     "asynchronous",
@@ -17,6 +17,6 @@
   "main": "streamz.js",
   "license": "MIT",
   "dependencies": {
-    "bluebird": "~3.2.2"
+    "bluebird": "~3.4.6"
   }
 }

--- a/streamz.js
+++ b/streamz.js
@@ -51,7 +51,13 @@ function Streamz(_c,fn,options) {
     }
   });
 
-  this.on('pipe',function() {
+  this.on('pipe',function(p) {
+    var self = this;
+    if (!(p instanceof Streamz) && (!p._events.error || !p._events.error.length))
+      p.on('error',function(e) {
+        self.emit('error',e);
+      });
+
     this._incomingPipes++;
   });
 }
@@ -165,7 +171,7 @@ Streamz.prototype.promise = function() {
     self.pipe(bufferStream)
       .on('error',reject)
       .on('finish',function() {
-        resolve(buffer)
+        resolve(buffer);
       });
   });
 };


### PR DESCRIPTION
From streams that are not `streamz` objects and do not already have an error handler in place