### PR TITLE
Only set default highWaterMark if undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streamz",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "A Swiss-army-knife of a stream",
   "keywords": [
     "asynchronous",

--- a/streamz.js
+++ b/streamz.js
@@ -27,7 +27,9 @@ function Streamz(_c,fn,options) {
 
   options = options || {};
   options.objectMode = true;
-  options.highWaterMark = options.highWaterMark || 10;
+
+  if (options.highWaterMark === undefined) 
+    options.highWaterMark = 10;
 
   stream.Transform.call(this,options);
 


### PR DESCRIPTION
This allows setting highWaterMark to be explicitly zero