### PR TITLE
Finalize

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streamz",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "description": "A Swiss-army-knife of a stream",
   "keywords": [
     "asynchronous",

--- a/streamz.js
+++ b/streamz.js
@@ -42,6 +42,8 @@ function Streamz(_c,fn,options) {
 
   this._incomingPipes = (options.keepAlive ? 1 : 0);
   this._concurrent = 0;
+  if (options.flush)
+    this._flush = options.flush;
 
   this.on('error',function(e) {
     if (this._events.error.length < 2) {
@@ -67,6 +69,8 @@ function Streamz(_c,fn,options) {
 util.inherits(Streamz,stream.Transform);
 
 Streamz.prototype.callbacks = undefined;
+
+Streamz.prototype._flush = function(cb) { setImmediate(cb);};
 
 Streamz.prototype._transform = function(d,e,_cb) {
   var self = this,

--- a/test/callback-and-promise-test.js
+++ b/test/callback-and-promise-test.js
@@ -58,15 +58,13 @@ describe('callback and promise',function() {
   input.end();
 
   var concurrent = 0,
-      maxConcurrent = 0,
-      concurrentAtEnd,
-      timeAtEnd;
+      maxConcurrent = 0;
 
   var main = streamz(function(d,cb) {
     var self = this;
     maxConcurrent = Math.max(maxConcurrent,concurrent++);
     return pool.getConnection()
-      .then(function(connection) {      
+      .then(function(connection) {
         cb(null,'callback'); // signal we have received connection
         return connection.query
           .then(function() {
@@ -76,10 +74,6 @@ describe('callback and promise',function() {
             return 'promise';
           });
       });
-  })
-  .on('finish',function() { 
-    concurrentAtEnd = concurrent;
-    timeAtEnd = Number(new Date());
   });
 
   input
@@ -91,18 +85,6 @@ describe('callback and promise',function() {
   it('maximum concurrency controlled by callbacks',function() {
     return done.then(function() {
       assert.equal(maxConcurrent,poolSize);
-    });
-  });
-
-  it('concurrency at the end is controlled by callbacks',function() {
-    return done.then(function() {
-      assert.equal(concurrentAtEnd,poolSize);
-    });
-  });
-
-  it('next stream only finishes when prev outstanding promises are resolved',function() {
-    return done.then(function() {
-      assert(Number(new Date())-timeAtEnd > queryDelay,'duration is longer than promise delay');
     });
   });
 

--- a/test/flush-test.js
+++ b/test/flush-test.js
@@ -1,0 +1,29 @@
+var streamz = require('../streamz'),
+    source = require('./lib/source'),
+    assert = require('assert');
+
+var values = [1,2,3,4,5,6,7,8,9];
+
+describe('custom flush',function() {
+   it('is executed after finish',function() {
+    var s = streamz(function(d) {
+      // Build a buffer
+      this.buffer = this.buffer || [];
+      this.buffer.push(d);
+    },{
+      // Flush the buffer at finish
+      flush: function(cb) {
+        this.push(this.buffer);
+        cb();
+      }
+    });
+
+    return source(values)
+      .pipe(s)
+      .promise()
+      .then(function(d) {
+        assert.deepEqual(d,[values]);
+      });
+  });
+
+});

--- a/test/function-test.js
+++ b/test/function-test.js
@@ -103,6 +103,28 @@ describe('function',function() {
       });
     });
 
+    describe('with this.write after stream has ended',function() {
+     it('processes data',function() {
+        var s = streamz(function(d) {
+          var self = this;
+          if (d === 8 || d === 9)
+            return Promise.delay(10)
+              .then(function() {
+                self.write(d+2);
+              });
+          else
+            return d;
+        });
+
+        return source(values)
+          .pipe(s)
+          .promise()
+          .then(function(d) {
+            assert.deepEqual(d,[1,2,3,4,5,6,7,10,11]);
+          });
+      });
+    });
+
     describe('with callback',function() {
       it('processes data',function() {
         return test(streamz(function(d,cb) {
@@ -130,6 +152,7 @@ describe('function',function() {
     });
   });
 
+
   describe('async without cb or promise',function() {
     it('fails to capture the data',function() {
       return test(streamz(function(d) {
@@ -145,5 +168,7 @@ describe('function',function() {
       },Object);
     });
   });
+
+
 
 });


### PR DESCRIPTION
Instead of monitoring finalize after end through _flush we pause ending the stream until all concurrent requests are done *and* writable buffer is zero.    Looking for zero-length writable buffer allows `write` to self within the transform even if the inbound pipe(s) have ended.

This allows for simple custom `_flush` by extension or by defining `flush` as a property in options.