### PR TITLE
maxBuffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Any errors that come up in a streamz object are passed to the children if no cus
 
 A chain that ends with `.promise()` returns a promise that collects any data passed down in an array and resolves when the stream is `finished` or is rejected if any uncaught error occured.   If no data is passed down to the end, the promise simply resolves to an empty array.
 
-Optionally a `maxBuffer` option can prevent the array size from growing out of bounds. If stream data type is `Object`, maxBuffer will limit number of objects, rather than the underlying byteLength.
+Optionally a `maxBuffer` option can prevent the array size from growing out of bounds. If stream data type is an `Object` or `Array` of objects, maxBuffer will limit number of objects, rather than the underlying byteLength.
 
 Example of promise with 4mb buffer size limit
 ```js

--- a/README.md
+++ b/README.md
@@ -66,3 +66,10 @@ streamz(function(d) {
 Any errors that come up in a streamz object are passed to the children if no custom error listener has been defined.  This allows errors to propagate down to the first error listener or to the rejection of a final promise (if the chain ends in `.promise()`)
 
 A chain that ends with `.promise()` returns a promise that collects any data passed down in an array and resolves when the stream is `finished` or is rejected if any uncaught error occured.   If no data is passed down to the end, the promise simply resolves to an empty array.
+
+Optionally a `maxBuffer` option can prevent the array size from growing out of bounds. If stream data type is `Object`, maxBuffer will limit number of objects, rather than the underlying byteLength.
+
+Example of promise with 4mb buffer size limit
+```js
+streamz(fn, {maxBuffer:41943040}).promise();
+```

--- a/streamz.js
+++ b/streamz.js
@@ -168,8 +168,16 @@ Streamz.prototype.end = function(d,cb) {
 };
 
 Streamz.prototype.promise = function() {
+  let size = 0;
   const buffer = [];
   const bufferStream = Streamz(d => {
+    if (this.options.maxBuffer) {
+      size += (d && d.length) || 1;
+      if (size > this.options.maxBuffer) {
+        this.emitError(new Error('max buffer size reached'));
+        return;
+      }
+    }
     buffer.push(d);
   });
         

--- a/test/max-buffer-test.js
+++ b/test/max-buffer-test.js
@@ -3,35 +3,50 @@ const t = require('tap');
 const valueStream = require('./lib/source');
 
 const maxBuffer = 5;
-const smValue = [1,2,3,4];
-const mdValue = [1,2,3,4,5];
-const lgValue = [1,2,3,4,5,6];
+const smArrayValue = [1,2,3,4];
+const mdArrayValue = [1,2,3,4,5];
+const lgArrayValue = [1,2,3,4,5,6];
+const smStringValue = smArrayValue.join('');
+const mdStringValue = mdArrayValue.join('');
+const lgStringValue = lgArrayValue.join('');
+const smBufferValue = Buffer.from(smArrayValue);
+const mdBufferValue = Buffer.from(mdArrayValue);
+const lgBufferValue = Buffer.from(lgArrayValue);
+
+const testSuccess = (t,val) => valueStream(val)
+  .pipe(streamz({maxBuffer}))
+  .promise()
+  .then(d => t.same(d, [].concat(val)));
+
+const testRejection = (t,val) => {
+  let err;
+  return valueStream(val)
+    .pipe(streamz({maxBuffer}))
+    .promise()
+    .catch(e => err = e)
+    .then(() => {
+      t.same(err.message, 'max buffer size reached');
+    });
+};
 
 t.test('max-buffer', {autoend:true, jobs: 10}, t => {
 
-  t.test('allows in bounds', t => {
-    return valueStream(smValue)
-      .pipe(streamz({maxBuffer}))
-      .promise()
-      .then(d => t.same(d, smValue));
+  t.test('allows in bounds', {autoend:true, jobs: 10}, t => {
+    t.test('array', t => testSuccess(t, smArrayValue));
+    t.test('string', t => testSuccess(t, smStringValue));
+    t.test('buffer', t => testSuccess(t, smBufferValue));
   });
 
-  t.test('allows at capacity', t => {
-    return valueStream(mdValue)
-      .pipe(streamz({maxBuffer}))
-      .promise()
-      .then(d => t.same(d, mdValue));
+  t.test('allows at capacity', {autoend:true, jobs: 10}, t => {
+    t.test('array', t => testSuccess(t, mdArrayValue));
+    t.test('string', t => testSuccess(t, mdStringValue));
+    t.test('buffer', t => testSuccess(t, mdBufferValue));
   });
 
-  t.test('rejects at max buffer size', t => {
-    let err;
-    return valueStream(lgValue)
-      .pipe(streamz({maxBuffer}))
-      .promise()
-      .catch(e => err = e)
-      .then(() => {
-        t.same(err.message, 'max buffer size reached');
-      });
+  t.test('rejects at max buffer size', {autoend:true, jobs: 10}, t => {
+    t.test('array', t => testRejection(t, lgArrayValue));
+    t.test('string', t => testRejection(t, lgStringValue));
+    t.test('buffer', t => testRejection(t, lgBufferValue));
   });
 
 });

--- a/test/max-buffer-test.js
+++ b/test/max-buffer-test.js
@@ -1,0 +1,37 @@
+const streamz = require('../streamz');
+const t = require('tap');
+const valueStream = require('./lib/source');
+
+const maxBuffer = 5;
+const smValue = [1,2,3,4];
+const mdValue = [1,2,3,4,5];
+const lgValue = [1,2,3,4,5,6];
+
+t.test('max-buffer', {autoend:true, jobs: 10}, t => {
+
+  t.test('allows in bounds', t => {
+    return valueStream(smValue)
+      .pipe(streamz({maxBuffer}))
+      .promise()
+      .then(d => t.same(d, smValue));
+  });
+
+  t.test('allows at capacity', t => {
+    return valueStream(mdValue)
+      .pipe(streamz({maxBuffer}))
+      .promise()
+      .then(d => t.same(d, mdValue));
+  });
+
+  t.test('rejects at max buffer size', t => {
+    let err;
+    return valueStream(lgValue)
+      .pipe(streamz({maxBuffer}))
+      .promise()
+      .catch(e => err = e)
+      .then(() => {
+        t.same(err.message, 'max buffer size reached');
+      });
+  });
+
+});


### PR DESCRIPTION
Node.js Buffers can reach up to 2GB. This PR adds a `maxBuffer` size limit option for the buffer used in streamz.promise

> On 32-bit architectures, this value is (2^30)-1 (~1GB). On 64-bit architectures, this value is (2^31)-1 (~2GB).

https://nodejs.org/api/buffer.html#buffer_buffer_constants_max_length

```js
(require('buffer').constants.MAX_LENGTH + 1) / 2**30
```
https://stackoverflow.com/a/54857532/2474735